### PR TITLE
Fix: Use pipe instead of process substitution in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Watch live demo video showcasing the CK-X Simulator in action:
 
 #### Linux & macOS
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/nishanb/ck-x/master/scripts/install.sh)
+curl -fsSL https://raw.githubusercontent.com/nishanb/ck-x/master/scripts/install.sh | bash
 ```
 
 #### Windows ( Windows installation is unstable and not supported yet, may break during setup )

--- a/scripts/COMPOSE-DEPLOY.md
+++ b/scripts/COMPOSE-DEPLOY.md
@@ -17,7 +17,13 @@ This guide provides instructions for deploying the CK-X Simulator on different o
 Open Terminal and run:
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/nishanb/CK-X/master/scripts/install.sh)
+curl -fsSL https://raw.githubusercontent.com/nishanb/CK-X/master/scripts/install.sh | bash
+```
+
+or, if the current user does not have the permission to run docker commands:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nishanb/CK-X/master/scripts/install.sh | sudo bash
 ```
 
 ### Windows


### PR DESCRIPTION
# What this PR does

This PR updates the quick install command in the documentation and/or script logic by replacing the process substitution syntax:

```bash
bash <(curl -fsSL https://raw.githubusercontent.com/nishanb/CK-X/master/scripts/install.sh)
```

with a more compatible version using a pipe:

```bash
curl -fsSL https://raw.githubusercontent.com/nishanb/CK-X/master/scripts/install.sh | bash
```

---

# Why it's needed

On some systems (e.g. Debian 12), the original process substitution fails with:

```
bash: /dev/fd/63: No such file or directory
curl: (23) Failure writing output to destination
```

This is likely caused by how `/dev/fd` handles file descriptors under `sudo`, especially when used in combination with `bash <(...)`.

Using a pipe (`|`) avoids these issues entirely and makes the install process more reliable and portable across environments.

---

# How to test

Run the following command on a system affected by the issue (use sudo before `bash` if needed):

```bash
curl -fsSL https://raw.githubusercontent.com/<your-fork>/CK-X/<your-branch>/scripts/install.sh | bash
```

Expected result: The installer runs successfully without any `/dev/fd` errors.

---

# Related issue

Refs: #2 

## 💬 **Comment for the Contributor**

Hey! 👋 I ran into this issue on Debian 12 and tracked it down to the use of process substitution with sudo. Switching to a pipe resolved the problem consistently.

Let me know if you'd prefer this change handled differently.  
Thanks for the great project!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised installation instructions for the CK-X Simulator to streamline command execution on Linux and macOS.
  - Added an alternative command utilizing elevated privileges for users who encounter permission issues during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->