### PR TITLE
docs: Fix broken links to non-existing subdir

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing! Here's how you can help:
 ## Quick Start
 
 1. Fork and clone the [repository](https://github.com/@nishanb/CK-X)
-2. Follow our [Development Setup Guide](docs/development-setup.md)
+2. Follow our [Development Setup Guide](development-setup.md)
 3. Create a new branch for your changes
 4. Submit a Pull Request
 
@@ -22,7 +22,7 @@ Thank you for your interest in contributing! Here's how you can help:
 - Focus on teaching concepts
 
 ### Lab Guidelines
-- Follow [Lab Creation Guide](docs/how-to-add-new-labs.md)
+- Follow [Lab Creation Guide](how-to-add-new-labs.md)
 - Include verification scripts
 - Test thoroughly
 - Provide clear instructions


### PR DESCRIPTION
# What this PR does

This PR fixes broken links in the documentation that were pointing to non-existent subdirectories. The affected links have been updated to point to the correct paths.

---

# Why it's needed

Some links in the documentation were incorrectly pointing to subdirectories that did not exist, leading to 404 errors when trying to access them. Fixing these links ensures that users can navigate the documentation without encountering broken references.

---

# How to test

Simply check the updated documentation links to ensure they direct you to the correct pages.

Expected result: All links in the documentation should now work as expected, with no 404 errors.

---

# 💬 Comment for the Contributor

Hey! 👋 I noticed some broken links in the documentation that were pointing to non-existent subdirectories. I’ve fixed them to point to the correct paths.

Let me know if you have any questions or if you'd like me to make further adjustments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the contributor guidelines by revising link references for developer setup and lab creation guides.
  - The adjustments streamline the paths for accessing these resources while keeping the content unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->