### PR TITLE
Fix: CKAD 001 Q6 - nginx container cannot start

### DIFF
--- a/facilitator/assets/exams/ckad/001/answers.md
+++ b/facilitator/assets/exams/ckad/001/answers.md
@@ -115,13 +115,13 @@ spec:
     image: nginx
     volumeMounts:
     - name: log-volume
-      mountPath: /var/log
+      mountPath: /var/my-log
   - name: sidecar
     image: busybox
-    command: ["sh", "-c", "while true; do date >> /var/log/date.log; sleep 10; done"]
+    command: ["sh", "-c", "while true; do date >> /var/my-log/date.log; sleep 10; done"]
     volumeMounts:
     - name: log-volume
-      mountPath: /var/log
+      mountPath: /var/my-log
   volumes:
   - name: log-volume
     emptyDir: {}
@@ -140,7 +140,7 @@ You can verify the pod is working correctly:
 kubectl get pod sidecar-pod -n troubleshooting
 
 # Verify the shared volume is mounted and the log file is being written
-kubectl exec -it sidecar-pod -n troubleshooting -c nginx -- cat /var/log/date.log
+kubectl exec -it sidecar-pod -n troubleshooting -c nginx -- cat /var/my-log/date.log
 
 # Check events related to the pod
 kubectl describe pod sidecar-pod -n troubleshooting

--- a/facilitator/assets/exams/ckad/001/assessment.json
+++ b/facilitator/assets/exams/ckad/001/assessment.json
@@ -168,7 +168,7 @@
             "id": "6",
             "namespace": "troubleshooting",
             "machineHostname": "ckad9999",
-            "question": "The DevOps team needs a specialized pod to help with monitoring and logging. \n\nCreate a multi-container pod named `sidecar-pod` in the `troubleshooting` namespace with the following specifications: \n\n1. Main container: \n   - Image: `nginx` \n   - Purpose: Serve web content \n\n2. Sidecar container: \n   - Image: `busybox` \n   - Command: [`sh`, `-c`, `while true; do date >> /var/log/date.log; sleep 10; done`] \n\n3. Shared volume configuration: \n   - Volume name: `log-volume` \n   - Mount path: `/var/log` in both containers \n\nThis demonstrates the sidecar container pattern for extending application functionality.",
+            "question": "The DevOps team needs a specialized pod to help with monitoring and logging. \n\nCreate a multi-container pod named `sidecar-pod` in the `troubleshooting` namespace with the following specifications: \n\n1. Main container: \n   - Image: `nginx`\n   - Container name: `nginx` \n   - Purpose: Serve web content \n\n2. Sidecar container: \n   - Image: `busybox`\n   - Container name: `sidecar` \n   - Command: [`sh`, `-c`, `while true; do date >> /var/my-log/date.log; sleep 10; done`] \n\n3. Shared volume configuration: \n   - Volume name: `log-volume` \n   - Mount path: `/var/my-log` in both containers \n\nThis demonstrates the sidecar container pattern for extending application functionality.",
             "concepts": ["pods", "multi-container", "volumes", "sidecar-pattern"],
             "verification": [
                 {


### PR DESCRIPTION
### Issues Identified

There are two main problems with CKAD 001, Question 6:

1. Unspecified Container Names:
    The question does not specify the names of the containers within the pod. However, the test cases expect containers named `nginx` and `sidecar`. Without explicitly stating these container names in the question, test takers cannot reliably pass the test.

2. Volume Mount Path Conflict Causing CrashLoopBackOff:
   The nginx container fails to access its error log at `/var/log/nginx/error.log` due to a conflict with the mounted volume path `/var/log`. This results in the nginx container entering a CrashLoopBackOff state.

Evidence of the Issue:
Pod status output shows the sidecar-pod is crashing:
```
NAME                          READY   STATUS             RESTARTS       AGE
broken-app-6979d6867f-mp2z9   0/1     ImagePullBackOff   0              10m
broken-app-6979d6867f-xxf9k   0/1     ImagePullBackOff   0              10m
logging-pod                   2/2     Running            0              10m
sidecar-pod                   1/2     CrashLoopBackOff   6 (2m8s ago)   8m5s
web-app-bcdf75d4d-jnkc4       1/1     Running            0              10m
web-app-bcdf75d4d-sgkhx       1/1     Running            0              10m
```

Logs from the nginx container confirm the error:
```
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
2025/04/14 23:44:37 [emerg] 1#1: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
```

### Changes Introduced by This PR

1. Clarify Container Names: Explicitly specify the container names nginx and sidecar in the CKAD 001 Question 6 question to align with test case expectations.
2. Resolve Volume Mount Conflict: Change the volume mount path from `/var/log` to `/var/my-log` in the sidecar-pod.yaml file to prevent interference with the nginx container’s log directory.
3. Update Answer Key: Modify the official answer for Question 6 in CKAD 001 to reflect these changes.
