### PR TITLE
Fix: unable to copy question commands to remote-desktop clipboard

### DIFF
--- a/remote-desktop/agent.py
+++ b/remote-desktop/agent.py
@@ -23,6 +23,7 @@ class RequestHandler(BaseHTTPRequestHandler):
                     self.respond(400, {"error": "Missing clipboard content"})
                     return
                 
+                clipboard_content = clipboard_content.replace("'", "'\\''")
                 command = "echo -n '" + clipboard_content + "' | xclip -selection clipboard &"
                 subprocess.Popen(command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 


### PR DESCRIPTION
#### 🧾 What this PR does

This pull request fix a bug where test takers are unable to copy `command` section in the CKAD 002 Question 2, Question 8, Question 13, and Question 14.

![ckx_bug](https://github.com/user-attachments/assets/62a38e5a-16c6-4c29-b5fe-9c889e3a92df)

#### Problem and Proposed solution

The root cause of this issue is the presence of the single quote character `'` in the command text, which disrupts the clipboard functionality in the `remote-desktop` service.

To resolve this issue, one possible solution is to programmatically escape the single quote character before passing the command to the `echo` command. This should allow users to copy the commands without any problems.


#### 🧩 Type of change

- [x] Bug fix  

#### 🧪 How to test it

Users should be able to copy given commands in the aformentioned questions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of clipboard content to prevent issues when pasting text containing single quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->