### PR TITLE
fix CKAD lab2 question 14: Use fqdn for myservice nslookup

### DIFF
--- a/facilitator/assets/exams/ckad/002/answers.md
+++ b/facilitator/assets/exams/ckad/002/answers.md
@@ -653,7 +653,7 @@ spec:
   initContainers:
   - name: sidecar-container
     image: busybox
-    command: ['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done']
+    command: ['sh', '-c', 'until nslookup myservice.init-containers.svc.cluster.local; do echo waiting for myservice; sleep 2; done']
     volumeMounts:
     - name: log-volume
       mountPath: /shared

--- a/facilitator/assets/exams/ckad/002/answers.md
+++ b/facilitator/assets/exams/ckad/002/answers.md
@@ -62,6 +62,9 @@ spec:
     volumeMounts:
     - name: log-volume
       mountPath: /var/log
+    - name: log-volume
+      mountPath: /var/log/nginx
+      subPath: nginx
   - name: sidecar-container
     image: busybox
     command: ['sh', '-c', 'while true; do echo $(date) >> /var/log/app.log; sleep 5; done']

--- a/facilitator/assets/exams/ckad/002/assessment.json
+++ b/facilitator/assets/exams/ckad/002/assessment.json
@@ -520,7 +520,7 @@
             "id": "14",
             "namespace": "init-containers",
             "machineHostname": "ckad9999",
-            "question": "Create a Pod named `app-with-init` in the `init-containers` namespace with the following specifications:\n\n1. Main container using image `nginx`\n2. Init container using image `busybox` with command: `['sh', '-c', 'until nslookup myservice; do echo waiting for myservice; sleep 2; done']`\n3. Create a service named `myservice` using image `nginx`\n4. Share a volume between init container and main container at `/shared`\n\nEnsure the namespace exists before creating the resources.",
+            "question": "Create a Pod named `app-with-init` in the `init-containers` namespace with the following specifications:\n\n1. Main container using image `nginx`\n2. Init container using image `busybox` with command: `['sh', '-c', 'until nslookup myservice.init-containers.svc.cluster.local; do echo waiting for myservice; sleep 2; done']`\n3. Create a service named `myservice` using image `nginx`\n4. Share a volume between init container and main container at `/shared`\n\nEnsure the namespace exists before creating the resources.",
             "concepts": ["init-containers", "services", "shared-volumes"],
             "verification": [
                 {

--- a/facilitator/assets/exams/ckad/002/scripts/validation/q14_s2_validate_pod.sh
+++ b/facilitator/assets/exams/ckad/002/scripts/validation/q14_s2_validate_pod.sh
@@ -20,7 +20,7 @@ if [[ "$POD" == "app-with-init" ]]; then
     
     if [[ "$MAIN_CONTAINER_IMAGE" == "nginx" && 
           "$INIT_CONTAINER_IMAGE" == "busybox" && 
-          "$INIT_CONTAINER_COMMAND" == *"nslookup myservice"* ]]; then
+          "$INIT_CONTAINER_COMMAND" == *"nslookup myservice.init-containers.svc.cluster.local"* ]]; then
         # Pod and init container are configured correctly
         exit 0
     else
@@ -28,7 +28,7 @@ if [[ "$POD" == "app-with-init" ]]; then
         echo "Found main container image: $MAIN_CONTAINER_IMAGE (expected: nginx)"
         echo "Found init container: $INIT_CONTAINER"
         echo "Found init container image: $INIT_CONTAINER_IMAGE (expected: busybox)"
-        echo "Found init container command: $INIT_CONTAINER_COMMAND (should include 'nslookup myservice')"
+        echo "Found init container command: $INIT_CONTAINER_COMMAND (should include 'nslookup myservice.init-containers.svc.cluster.local')"
         exit 1
     fi
 else

--- a/facilitator/assets/exams/ckad/002/scripts/validation/q2_s4_validate_shared_volume.sh
+++ b/facilitator/assets/exams/ckad/002/scripts/validation/q2_s4_validate_shared_volume.sh
@@ -7,7 +7,7 @@ VOLUME_NAME=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath
 if [[ "$VOLUME_NAME" == "log-volume" ]]; then
     # Volume exists, now check if it's mounted in both containers
     MAIN_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="main-container")].volumeMounts[?(@.name=="log-volume")]}' 2>/dev/null)
-    SIDECAR_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="sidecar-container")].volumeMounts[?(@.name=="log-volume")]}' 2>/dev/null)
+    SIDECAR_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="sidecar-container")].volumeMounts[?(@.name=="log-volume")].mountPath}' 2>/dev/null)
 
     if [[ "$MAIN_CONTAINER_MOUNT" == *"/var/log"* && "$SIDECAR_CONTAINER_MOUNT" == "/var/log" ]]; then
         # Both containers have the volume mounted at the correct path

--- a/facilitator/assets/exams/ckad/002/scripts/validation/q2_s4_validate_shared_volume.sh
+++ b/facilitator/assets/exams/ckad/002/scripts/validation/q2_s4_validate_shared_volume.sh
@@ -6,10 +6,10 @@ VOLUME_NAME=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath
 
 if [[ "$VOLUME_NAME" == "log-volume" ]]; then
     # Volume exists, now check if it's mounted in both containers
-    MAIN_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="main-container")].volumeMounts[?(@.name=="log-volume")].mountPath}' 2>/dev/null)
-    SIDECAR_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="sidecar-container")].volumeMounts[?(@.name=="log-volume")].mountPath}' 2>/dev/null)
-    
-    if [[ "$MAIN_CONTAINER_MOUNT" == "/var/log" && "$SIDECAR_CONTAINER_MOUNT" == "/var/log" ]]; then
+    MAIN_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="main-container")].volumeMounts[?(@.name=="log-volume")]}' 2>/dev/null)
+    SIDECAR_CONTAINER_MOUNT=$(kubectl get pod multi-container-pod -n multi-container -o jsonpath='{.spec.containers[?(@.name=="sidecar-container")].volumeMounts[?(@.name=="log-volume")]}' 2>/dev/null)
+
+    if [[ "$MAIN_CONTAINER_MOUNT" == *"/var/log"* && "$SIDECAR_CONTAINER_MOUNT" == "/var/log" ]]; then
         # Both containers have the volume mounted at the correct path
         exit 0
     else
@@ -21,4 +21,4 @@ if [[ "$VOLUME_NAME" == "log-volume" ]]; then
 else
     echo "Volume 'log-volume' does not exist in pod 'multi-container-pod'"
     exit 1
-fi 
+fi


### PR DESCRIPTION
fix CKAD lab2 question 14: Use fqdn for myservice nslookup

---

#### 🧾 What this PR does

This PR fixes CKAD Lab 2 – Question 14 by updating the nslookup command to use the fully qualified domain name (FQDN) for myservice.
This ensures correct DNS resolution across namespaces and local dns setups. This aligns the lab solution with Kubernetes DNS best practices.

---

#### 🧩 Type of change

- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (please describe): ____________

---

#### 🧪 How to test it

Run CKAD Lab 2 – Question 14.

Execute the provided solution using nslookup myservice.<namespace>.svc.cluster.local.

Verify that the service resolves correctly and the command returns the expected DNS record.

---

#### ✅ Acceptance Criteria

- [x] Pod starts without errors  
- [ ] Docker Compose logs are available  
- [x] All relevant tests pass  
- [ ] Documentation is updated (if needed - usually it is)

<!-- If you are adding labs, please, also add the following -->

- [ ] New labs pass  
- [ ] Answers work as expected  

---

#### 📎 Related Issue(s)

<!-- Mention any related issues.

Example: "Closes #42" or "Refs #15"

-->

---

#### 💬 Notes for Reviewers

<!-- Add any extra context or notes for the reviewer.  

Example: "I also tweaked the wording of the exercise to explicitly define container names."

-->

---

#### 🧠 Additional Context

<!--

Add any background or technical context that might help reviewers understand the motivation or constraints of the PR.

-->

---

#### 📄 Attachments

<!-- Add any relevant attachments such as:  

- Screenshots of the labs list showing the the newly added labs
- Screenshots of the labs running
- Screenshots of the labs passing
- E2E test results (screenshots or, preferably, logs/human-readable reports)
- Static code analysis reports
- Any other supporting material (e.g. logs, error traces, terminal output)

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CKAD exam question 14 to require a fully qualified DNS name for init-container service resolution; instructions and validation messaging reflect the FQDN requirement.
* **Tests**
  * Validation checks adjusted to expect the FQDN in the init-container readiness verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->